### PR TITLE
Use absolute paths plus the baseurl.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ author:
   url: "nipy.github.io"
 
 # Build settings
-baseurl: "/nipy-jekyll/"
+baseurl: "/nipy-jekyll"
 markdown: kramdown
 source: .
 destination: ./_site

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,17 +11,17 @@
        <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
        <script src="//code.jquery.com/jquery-1.11.1.min.js"></script>
        <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.5/d3.min.js"></script> 
-       <script src="{{ "js/tipsy.js" | prepend: site.baseurl }}"></script>
+       <script src="{{ "/js/tipsy.js" | prepend: site.baseurl }}"></script>
        
 
 	<!-- CSS & fonts -->
-       <link rel="stylesheet" href="{{ "css/bootstrap.min.css" | prepend: site.baseurl }}">
-       <link rel="stylesheet" href="{{ "css/main.css" | prepend: site.baseurl }}">
+       <link rel="stylesheet" href="{{ "/css/bootstrap.min.css" | prepend: site.baseurl }}">
+       <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
        <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
 	<link href='https://fonts.googleapis.com/css?family=Roboto:300' rel='stylesheet' type='text/css'>
 
 
 	<!-- RSS -->
-	<link href="/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed" />
+	<link href="{{ "/atom.xml" | prepend: site.baseurl }}" type="application/atom+xml" rel="alternate" title="ATOM Feed" />
 
 </head>

--- a/_includes/link.html
+++ b/_includes/link.html
@@ -1,5 +1,5 @@
-<a href="{{ site.baseurl }}index.html">Blog</a>
-<a href="{{ site.baseurl }}help.html">Help</a>
-<a href="{{ site.baseurl }}conduct.html">Conduct</a>
-<a href="{{ site.baseurl }}contribute.html">Contribute</a>
+<a href="{{ "/index.html" | prepend: site.baseurl }}">Blog</a>
+<a href="{{ "/help.html" | prepend: site.baseurl }}">Help</a>
+<a href="{{ "/conduct.html" | prepend: site.baseurl }}">Conduct</a>
+<a href="{{ "/contribute.html" | prepend: site.baseurl }}">Contribute</a>
 

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -1,7 +1,7 @@
 <nav {% if site.reverse == true %}id="nav-left"{% else %}id="nav"{% endif %}>
 
     <div id="nav-list">
-        <a href="{{ site.baseurl }}home.html">Home</a>
+        <a href="{{ "/home.html" | prepend: site.baseurl }}">Home</a>
 
         <!-- Nav pages -->
         <a href="#projects" class="list-group-item list-group-item" data-toggle="collapse">Projects <i class="fa fa-caret-down"></i></a>
@@ -11,7 +11,7 @@
             <a href='#{{ category.tag }}' class="list-group-item list-class" data-toggle="collapse" style="color:aqua;font-weight:400">{{ category.subtitle }}</a>
                 <div class="collapse" id="{{ category.tag }}" style="color:lime">
                 {% for package in category.packages %}
-                    <a href="{{ site.baseurl }}{{ package.tag }}.html" style="border-radius:0px; color:lime;" id="{{ package.tag }}" class="list-group-item list-project">{{ package.name }}</a>
+                    <a href="{{ "/" + package.tag + ".html" | prepend: site.baseurl }} style="border-radius:0px; color:lime;" id="{{ package.tag }}" class="list-group-item list-project">{{ package.name }}</a>
                 {% endfor %}
                 </div>
              {% endfor %}

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,1 +1,1 @@
-<script src="{{ "js/main.js" | prepend: site.baseurl }}"></script>
+<script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>

--- a/_includes/snakey.html
+++ b/_includes/snakey.html
@@ -5,7 +5,7 @@
             <div id="snakey"></div>
         </div>
         <div class="col-md-10">
-            <img src="{{ site.baseurl }}img/nipy.svg" width="150px">
+            <img src="{{ "/img/nipy.svg" | prepend: site.baseurl }}" width="150px">
         </div>
    </div>
 </div>
@@ -16,7 +16,7 @@ var tip = d3.tip()
     .attr('class', 'd3-tip')
     .offset([-10, 0])
     .html(function(d) {
-        return "<a href='{{ site.baseurl }}" + d.tag + ".html'><strong><span style='color:tomato'>" + d.tag + "</span></a>";
+        return "<a href='{{ "/" + d.tag + ".html" | prepend: site.baseurl }}'><strong><span style='color:tomato'>" + d.tag + "</span></a>";
 })
 
 // D3
@@ -84,7 +84,7 @@ var circle = svg.selectAll("circle")
     .on('mouseout.tip', tip.hide)
     .on('mouseover.tip', tip.show)
     .on('click', function(d){
-        window.location = "{{ site.baseurl }}" + d.tag + ".html";
+        window.location = "{{ d.tag + ".html" | prepend: site.baseurl }}";
     })
     .call(force.drag);
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,9 +27,9 @@
         {% if paginator.total_pages > 1 %}
             <div class="pagination">
             {% if paginator.previous_page == 1 %}
-            <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="page-item">&laquo;</a>
+            <a href="{{ '/' | prepend: site.baseurl }}" class="page-item">&laquo;</a>
             {% elsif paginator.previous_page%}
-            <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-item">&laquo;</a>
+            <a href="{{ paginator.previous_page_path | prepend: site.baseurl }}" class="page-item">&laquo;</a>
             {% else %}
             <span class="page-item">&laquo;</span>
             {% endif %}
@@ -38,14 +38,14 @@
                 {% if page == paginator.page %}
                 <span class="page-item">{{ page }}</span>
                 {% elsif page == 1 %}
-                <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="page-item">{{ page }}</a>
+                <a href="{{ '/' | prepend: site.baseurl }}" class="page-item">{{ page }}</a>
                 {% else %}
-                <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}" class="page-item">{{ page }}</a>
+                <a href="{{ site.paginate_path | prepend: site.baseurl | replace: ':num', page }}" class="page-item">{{ page }}</a>
                 {% endif %}
             {% endfor %}
         
             {% if paginator.next_page %}
-            <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-item">&raquo;</a>
+            <a href="{{ paginator.next_page_path | prepend: site.baseurl }}" class="page-item">&raquo;</a>
             {% else %}
             <span class="page-item">&raquo;</span>
             {% endif %}

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ general:
 
 test:
   override:
-    - BASEURL=https://circle-artifacts.com/gh/$CIRCLE_USERNAME/nipy-jekyll/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts/0/home/ubuntu/nipy-jekyll/_site/
+    - BASEURL=https://circle-artifacts.com/gh/$CIRCLE_USERNAME/nipy-jekyll/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts/0/home/ubuntu/nipy-jekyll/_site
     - echo $BASEURL
-    - sed -i "s,/nipy-jekyll/,$BASEURL,g" "_config.yml"
+    - sed -i "s,/nipy-jekyll,$BASEURL,g" "_config.yml"
     - jekyll build

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,6 @@ general:
 
 test:
   override:
-    - sed "s,/nipy-jekyll,https://circle-artifacts.com/gh/$CIRCLE_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM/artifacts/0$HOME/$CIRCLE_PROJECT_REPONAME/_site,g" "_config.yml" > "_circle_config.yml"
+    - sed "s,/nipy-jekyll,/gh/$CIRCLE_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM/artifacts/0$HOME/$CIRCLE_PROJECT_REPONAME/_site,g" "_config.yml" > "_circle_config.yml"
     - cat _circle_config.yml
     - jekyll build --config _circle_config.yml

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ general:
 
 test:
   override:
-    - BASEURL=https://circle-artifacts.com/gh/$CIRCLE_USERNAME/nipy-jekyll/$CIRCLE_PREVIOUS_BUILD_NUM/artifacts/0/home/ubuntu/nipy-jekyll/_site
-    - echo $BASEURL
-    - sed -i "s,/nipy-jekyll,$BASEURL,g" "_config.yml"
-    - jekyll build
+    - sed "s,/nipy-jekyll,https://circle-artifacts.com/gh/$CIRCLE_USERNAME/$CIRCLE_PROJECT_REPONAME/$CIRCLE_BUILD_NUM/artifacts/0$HOME/$CIRCLE_PROJECT_REPONAME/_site,g" "_config.yml" > "_circle_config.yml"
+    - cat _circle_config.yml
+    - jekyll build --config _circle_config.yml

--- a/home.html
+++ b/home.html
@@ -22,7 +22,7 @@ layout: default
                     </div>
                     <div id="pr{{ package.tag }}" class="panel-collapse collapse in">
                         <div class="panel-body">
-                        <p>{{ package.description }}</p> <a href="{{ site.baseurl }}{{ package.tag }}.html"> <span style="float:right">learn more</a></span></p>
+                        <p>{{ package.description }}</p> <a href="{{ "/" + package.tag | prepend: site.baseurl }}.html"> <span style="float:right">learn more</a></span></p>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ layout: default
 
 	  <li class="post">
                 <h2>{{ post.baseurl }}</h2>
-	  	<h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{{ post.title }}</a></h2>
+	  	<h2><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h2>
 	  	<time datetime="{{ post.date | date_to_xmlschema }}" class="by-line">{{ post.date | date_to_string }}</time>
 	  	<p>{{ post.content | strip_html | truncatewords:50 }}</p>
 	  </li>

--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@ layout: default
 	{% for post in paginator.posts %}
 
 	  <li class="post">
-                <h2>{{ post.baseurl }}</h2>
-	  	<h2><a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a></h2>
+        {# post url is absolute / fully qualified, so no need to prepend #}
+	  	<h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
 	  	<time datetime="{{ post.date | date_to_xmlschema }}" class="by-line">{{ post.date | date_to_string }}</time>
 	  	<p>{{ post.content | strip_html | truncatewords:50 }}</p>
 	  </li>


### PR DESCRIPTION
When coding, we have to distinguish between relative paths and absolute paths. I propose the following convention, to make it very clear:
- For absolute paths, specify the path as if our root is "/", and prepend baseurl:

```
<img src="{{ "/images/my_image.png" | prepend: site.baseurl }}" />
```
- For relative paths, specify the path without a leading slash:

```
<img src="images/my_image.png" />
```

This makes the intent very clear, without having to search whether baseurl was prepended. In order to do this, we simply need to make baseurl not have a trailing slash.

This PR changes the config so that baseurl does not have a trailing slash, and then fixes up the URLs to either use this convention, or (in some cases) start using the baseurl convention.
